### PR TITLE
Cap rq version below backwards incompatible 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     author_email='info@datamade.us',
     install_requires=[
         'django-councilmatic>=0.7,<=0.8.7',
+        'rq>=0.5.5,<1.0',
         'django-rq==0.9.3'
     ],
     classifiers=[


### PR DESCRIPTION
`django-rq==0.9.3` is not compatible with the `1.x` series of `rq`. This PR adds a compatible version of `rq` to `setup.py` prior to `django-rq`.